### PR TITLE
Fix clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We welcome contributions to bento.dev.
 To get started with contributing to bento.dev, you first need to [fork the repository](https://help.github.com/en/articles/fork-a-repo). Once you've done that you can clone the repository:
 
 ```sh
-$ git clone --recurse-submodules https://github.com/YOUR-USERNAME/bento.dev
+$ git clone --recurse-submodules git@github.com:YOUR-USERNAME/bento.dev.git
 ```
 
 ... and then install the dependencies via NPM:


### PR DESCRIPTION
```
$ git clone --recurse-submodules https://github.com/alanorozco/bento.dev
Cloning into 'bento.dev'...
Username for 'https://github.com': alanorozco
Password for 'https://alanorozco@github.com':
remote: Support for password authentication was removed on August 13, 2021. Please use a personal access token instead.
remote: Please see https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/ for more information.
fatal: Authentication failed for 'https://github.com/alanorozco/bento.dev/'
```