### PR TITLE
Fix safari spacings

### DIFF
--- a/styles/components/_component-doc.scss
+++ b/styles/components/_component-doc.scss
@@ -53,25 +53,25 @@
   h2,
   h3,
   h4 {
-    margin-block: var(--spacing-xl) var(--spacing-xs);
+    margin: var(--spacing-xl) 0 var(--spacing-xs);
 
     @include media('medium') {
-      margin-block: var(--spacing-xxl) var(--spacing-s);
+      margin: var(--spacing-xxl) 0 var(--spacing-s);
     }
   }
 
   h5,
   h6 {
-    margin-block: var(--spacing-l) var(--spacing-xs);
+    margin: var(--spacing-l) 0 var(--spacing-xs);
 
     @include media('medium') {
-      margin-block: var(--spacing-xl) var(--spacing-s);
+      margin: var(--spacing-xl) 0 var(--spacing-s);
     }
   }
 
   p,
   pre[class*='language-'] {
-    margin-block: var(--spacing-s);
+    margin: var(--spacing-s) 0;
   }
 
   h1 {
@@ -216,10 +216,10 @@
 
     td,
     th {
-      padding-block: var(--spacing-xxs);
+      padding: var(--spacing-xxs) 0;
 
       @include media('medium') {
-        padding-block: var(--spacing-xs);
+        padding: var(--spacing-xs) 0;
       }
     }
 
@@ -250,7 +250,7 @@
   hr {
     border: 0;
     border-bottom: solid 2px var(--light-sea-green);
-    margin-block: calc(var(--spacing-xxl) * 2);
+    margin: calc(var(--spacing-xxl) * 2) 0;
   }
 
   .bd-usage {
@@ -270,7 +270,7 @@
       font-size: 14px;
       font-weight: var(--semi-bold);
       line-height: 2;
-      margin-block: 0 var(--spacing-xs);
+      margin: 0 0 var(--spacing-xs);
     }
 
     @include media('medium') {

--- a/styles/components/_sidebar.scss
+++ b/styles/components/_sidebar.scss
@@ -52,8 +52,7 @@
 
       ol {
         margin: 0;
-        padding-inline-start: var(--spacing-s);
-        padding-block: var(--spacing-xs);
+        padding: var(--spacing-xs) 0 var(--spacing-xs) var(--spacing-s);
         &:first-child {
           padding: 0;
         }

--- a/styles/components/_stage.scss
+++ b/styles/components/_stage.scss
@@ -36,14 +36,14 @@
     font-weight: 250;
     letter-spacing: -0.5px;
     line-height: 1.18;
-    margin-block: calc(var(--spacing-l) * 7.25) var(--spacing-s);
+    margin: calc(var(--spacing-l) * 7.25) 0 var(--spacing-s);
 
     @include media('medium') {
       font-size: var(--font-size-56);
       font-weight: var(--thin);
       letter-spacing: -1px;
       line-height: 1.14;
-      margin-block: calc(var(--spacing-l) * 4.25) var(--spacing-xxl);
+      margin: calc(var(--spacing-l) * 4.25) 0 var(--spacing-xxl);
     }
 
     @include media('large') {

--- a/styles/pages/_404.scss
+++ b/styles/pages/_404.scss
@@ -36,10 +36,10 @@
 
       h2 {
         font-weight: 250;
-        margin-block: var(--spacing-xxs) var(--spacing-s);
+        margin: var(--spacing-xxs) 0 var(--spacing-s);
 
         @include media('medium') {
-          margin-block: var(--spacing-xs) var(--spacing-xl);
+          margin: var(--spacing-xs) 0 var(--spacing-xl);
         }
       }
     }

--- a/styles/pages/_blog-overview.scss
+++ b/styles/pages/_blog-overview.scss
@@ -61,7 +61,7 @@
       font-weight: var(--light);
       letter-spacing: 0.2px;
       line-height: 1.71;
-      margin-block: var(--spacing-xxs) var(--spacing-m);
+      margin: var(--spacing-xxs) 0 var(--spacing-m);
 
       @include media('large') {
         font-size: var(--font-size-16);
@@ -86,13 +86,13 @@
       font-weight: var(--light);
       letter-spacing: 0.2px;
       line-height: 1.71;
-      margin-block: var(--spacing-m) var(--spacing-xs);
+      margin: var(--spacing-m) 0 var(--spacing-xs);
 
       @include media('large') {
         font-size: var(--font-size-16);
         font-weight: 350;
         line-height: 2;
-        margin-block: var(--spacing-l) var(--spacing-s);
+        margin: var(--spacing-l) 0 var(--spacing-s);
       }
     }
   }

--- a/styles/pages/_components.scss
+++ b/styles/pages/_components.scss
@@ -8,7 +8,7 @@
     width: 90%;
 
     @include media('large') {
-      margin-block: calc(var(--spacing-xxl) * 1.25);
+      margin: calc(var(--spacing-xxl) * 1.25) auto;
       display: grid;
       grid-template-areas: 'sidebar main toc';
       grid-template-columns: minmax(max-content, auto) minmax(490px, 750px) 210px;

--- a/styles/pages/_documentation.scss
+++ b/styles/pages/_documentation.scss
@@ -66,7 +66,7 @@
 }
 
 .bd-cards {
-  margin-block: var(--spacing-xxl);
+  margin: var(--spacing-xxl) 0;
 
   h2 {
     margin-block-end: var(--spacing-m);
@@ -158,11 +158,11 @@
     font-size: var(--font-size-18);
     font-weight: var(--bold);
     line-height: 1.33;
-    margin-block: var(--spacing-xl) var(--spacing-s);
+    margin: var(--spacing-xl) 0 var(--spacing-s);
 
     @include media('xlarge') {
       font-size: var(--font-size-21);
-      margin-block: var(--spacing-xxl) var(--spacing-l);
+      margin: var(--spacing-xxl) 0 var(--spacing-l);
     }
   }
 
@@ -171,7 +171,7 @@
     font-weight: var(--bold);
     letter-spacing: 0.2px;
     line-height: 1.71;
-    margin-block: var(--spacing-xs) var(--spacing-xxs);
+    margin: var(--spacing-xs) 0 var(--spacing-xxs);
   }
 
   .bd-link,
@@ -197,9 +197,8 @@
         width: 60%;
       }
 
-      h6,
       p {
-        margin-block: var(--spacing-xs);
+        margin: var(--spacing-xs) 0;
       }
     }
     #bd-toc {

--- a/styles/pages/_home.scss
+++ b/styles/pages/_home.scss
@@ -80,12 +80,12 @@
   }
 
   .bd-latest-news {
-    margin-block: $spacing-small;
+    margin: $spacing-small 0;
     position: relative;
     z-index: 50;
 
     @include media('medium') {
-      margin-block: $spacing-big;
+      margin: $spacing-big 0;
 
       .bd-row__column {
         width: 70%;

--- a/styles/pages/_post.scss
+++ b/styles/pages/_post.scss
@@ -41,14 +41,14 @@
     }
 
     figure {
-      margin-block: var(--spacing-xxl) var(--spacing-xxs);
+      margin: var(--spacing-xxl) 0 var(--spacing-xxs);
       margin-inline: 0;
 
       &:first-of-type {
-        margin-block: var(--spacing-m) var(--spacing-xl);
+        margin: var(--spacing-m) 0 var(--spacing-xl);
 
         @include media('large') {
-          margin-block: var(--spacing-xl) var(--spacing-xxl);
+          margin: var(--spacing-xl) 0 var(--spacing-xxl);
         }
       }
 
@@ -60,7 +60,7 @@
     .bd-link {
       display: block;
       font-size: 14px;
-      margin-block: var(--spacing-xs) var(--spacing-xxl);
+      margin: var(--spacing-xs) 0 var(--spacing-xxl);
 
       @include media('large') {
         display: none;
@@ -97,10 +97,10 @@
       font-size: var(--font-size-34);
       letter-spacing: -0.5px;
       line-height: 1.18;
-      margin-block: var(--spacing-xl) var(--spacing-xs);
+      margin: var(--spacing-xl) 0 var(--spacing-xs);
 
       @include media('large') {
-        margin-block: var(--spacing-xxl) var(--spacing-m);
+        margin: var(--spacing-xxl) 0 var(--spacing-m);
       }
     }
 
@@ -126,10 +126,10 @@
     }
 
     .bd-navigation-container {
-      margin-block: calc(var(--spacing-xxl) * 1.5);
+      margin: calc(var(--spacing-xxl) * 1.5) 0;
 
       @include media('large') {
-        margin-block: calc(var(--spacing-xxl) * 2);
+        margin: calc(var(--spacing-xxl) * 2) 0;
       }
 
       hr {


### PR DESCRIPTION
For some weird reason the syntax  `margin-block: var(--spacing-xxl);` (The combination of block and variable) is not working on safari, so this PR refactors all occurrences along the code.

Fix https://github.com/ampproject/bento.dev/issues/120