### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The official homepage of the Bento.
 
 We welcome contributions to bento.dev.
 
-- **Bug reports and feature requests:** something missing or not working on [bento.dev](https://bento.dev)? Please file an issue [here](https://github.com/ampproject/bento.dev/issues/new).
+- **Bug reports and feature requests:** something missing or not working on [bento.dev](https://bentojs.dev)? Please file an issue [here](https://github.com/ampproject/bento.dev/issues/new).
 
 ## Setup
 


### PR DESCRIPTION
The link in the root README goes to [https://bento.dev](https://bento.dev) and states that is the page this repo is responsible for when it really should be [https://bentojs.dev](https://bentojs.dev).