### PR TITLE
Making sidebars sticky

### DIFF
--- a/site/_includes/partials/components/list.njk
+++ b/site/_includes/partials/components/list.njk
@@ -15,6 +15,6 @@
 <bento-sidebar class="bd-sidebar" id="bd-components" side="left" hidden>
   {{ components() }}
 </bento-sidebar>
-<div class="bd-sidebar__target">
+<div class="bd-sidebar__target bd-sidebar-components">
   {{ components() }}
 </div>

--- a/site/_includes/partials/components/toc.njk
+++ b/site/_includes/partials/components/toc.njk
@@ -7,6 +7,6 @@
 <bento-sidebar class="bd-sidebar" id="bd-toc" side="right" hidden>
   {{ toc() }}
 </bento-sidebar>
-<div class="bd-sidebar__target">
+<div class="bd-sidebar__target bd-sidebar-toc">
   {{ toc() }}
 </div>

--- a/styles/bento-dev.scss
+++ b/styles/bento-dev.scss
@@ -40,7 +40,6 @@ body {
   font-size: var(--font-size-16);
   font-family: var(--font-sans);
   font-weight: var(--normal);
-  overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   touch-action: manipulation;
@@ -49,6 +48,7 @@ body {
 
 body {
   display: grid;
+  overflow-x: hidden;
 }
 
 a {

--- a/styles/components/_sidebar.scss
+++ b/styles/components/_sidebar.scss
@@ -1,3 +1,12 @@
+@mixin sticky {
+  height: 80vh;
+  overflow: auto;
+  position: -webkit-sticky;
+  position: sticky;
+  top: 17%;
+  @include scrollbar;
+}
+
 .bd-sidebar {
   @include media('large') {
     display: none;
@@ -8,7 +17,18 @@
 
     @include media('large') {
       display: block;
+      @include sticky;
     }
+  }
+
+  &-components {
+    @include media('xlarge') {
+      width: 80%;
+    }
+  }
+
+  &-toc {
+    direction: rtl;
   }
 
   &__contents {


### PR DESCRIPTION
`position: sticky;` doesn't work if any ancestor has `overflow:hidden;`

This is causing a bug because of background image. Does anyone have an idea how to fix this?