### PR TITLE
Separate {% endexample %} tags from code blocks

### DIFF
--- a/gulpfile.js/importDocs.js
+++ b/gulpfile.js/importDocs.js
@@ -37,7 +37,7 @@ function _rewriteExamples(string) {
         startExample = false;
         endExample = true;
       } else if (endExample) {
-        line += '{% endexample %}';
+        line += '\n{% endexample %}';
         endExample = false;
       }
     }

--- a/site/en/components/bento-accordion.md
+++ b/site/en/components/bento-accordion.md
@@ -99,7 +99,8 @@ defineBentoAccordion();
     </bento-accordion>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Interactivity and API usage
 
@@ -170,7 +171,8 @@ const api = await accordion.getApi();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 #### Actions
 
@@ -535,7 +537,8 @@ function App() {
     </BentoAccordion>
   );
 }
-```{% endexample %}
+```
+{% endexample %}
 
 ### Interactivity and API usage
 
@@ -681,7 +684,8 @@ function App() {
     </BentoAccordion>
   )
 }
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 

--- a/site/en/components/bento-carousel.md
+++ b/site/en/components/bento-carousel.md
@@ -98,7 +98,8 @@ defineBentoBaseCarousel();
     </bento-base-carousel>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Interactivity and API usage
 
@@ -177,7 +178,8 @@ Bento components are highly interactive through their API. The `bento-base-carou
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ```javascript
 await customElements.whenDefined('bento-base-carousel');

--- a/site/en/components/bento-embedly-card.md
+++ b/site/en/components/bento-embedly-card.md
@@ -103,7 +103,8 @@ defineBentoEmbedlyCard();
     </bento-embedly-card>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -263,7 +264,8 @@ Programmatically changing any of the attribute values, will automatically update
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ---
 

--- a/site/en/components/bento-facebook.md
+++ b/site/en/components/bento-facebook.md
@@ -108,7 +108,8 @@ defineBentoFacebook();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ##### Embed a Facebook Video
 
@@ -172,7 +173,8 @@ defineBentoFacebook();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ##### Embed a Facebook Page
 
@@ -236,7 +238,8 @@ defineBentoFacebook();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ##### Embed a Facebook Like Button
 
@@ -283,7 +286,8 @@ defineBentoFacebook();
     </bento-facebook>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ##### Embed a Facebook Comment Section
 
@@ -330,7 +334,8 @@ defineBentoFacebook();
     </bento-facebook>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and Style
 

--- a/site/en/components/bento-fit-text.md
+++ b/site/en/components/bento-fit-text.md
@@ -84,7 +84,8 @@ defineBentoFitText();
     </bento-fit-text>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Overflowing content
 
@@ -211,7 +212,8 @@ Programmatically changing an attribute value will automatically update the eleme
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ---
 

--- a/site/en/components/bento-inline-gallery.md
+++ b/site/en/components/bento-inline-gallery.md
@@ -115,7 +115,8 @@ defineBentoInlineGallery();
     </bento-inline-gallery>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 

--- a/site/en/components/bento-instagram.md
+++ b/site/en/components/bento-instagram.md
@@ -85,7 +85,8 @@ defineBentoInstagram();
     </bento-instagram>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -189,7 +190,8 @@ By programmatically changing the `data-shortcode` attribute value, you can dynam
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Styling
 

--- a/site/en/components/bento-jwplayer.md
+++ b/site/en/components/bento-jwplayer.md
@@ -82,7 +82,8 @@ defineBentoJwplayer();
     ></bento-jwplayer>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Interactivity and API usage
 
@@ -146,7 +147,8 @@ You can use the API to trigger the available actions (`play`, `pause`, `mute`, `
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 

--- a/site/en/components/bento-lightbox-gallery.md
+++ b/site/en/components/bento-lightbox-gallery.md
@@ -90,7 +90,8 @@ defineBentoLightboxGallery();
     </figure>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 To use `bento-liightbox-gallery`, ensure the required script is included in your `<head>` section, then add the `lightbox` attribute on an `<img>` or `<bento-carousel>` element.
 

--- a/site/en/components/bento-lightbox.md
+++ b/site/en/components/bento-lightbox.md
@@ -92,7 +92,8 @@ defineBentoLightbox();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Interactivity and API usage
 
@@ -232,7 +233,8 @@ When the `scrollable` attribute is present, the content of the lightbox can scro
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ---
 

--- a/site/en/components/bento-mathml.md
+++ b/site/en/components/bento-mathml.md
@@ -92,7 +92,8 @@ defineBentoMathml();
     </p>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 

--- a/site/en/components/bento-selector.md
+++ b/site/en/components/bento-selector.md
@@ -84,7 +84,8 @@ defineBentoSelector();
     </bento-selector>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Usage notes
 

--- a/site/en/components/bento-sidebar.md
+++ b/site/en/components/bento-sidebar.md
@@ -103,7 +103,8 @@ defineBentoSidebar();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Interactivity and API usage
 

--- a/site/en/components/bento-social-share.md
+++ b/site/en/components/bento-social-share.md
@@ -100,7 +100,8 @@ defineBentoSocialShare();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -406,7 +407,8 @@ Programmatically changing any of the attribute values will automatically update 
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ---
 

--- a/site/en/components/bento-soundcloud.md
+++ b/site/en/components/bento-soundcloud.md
@@ -87,7 +87,8 @@ defineBentoSoundcloud();
     ></bento-soundcloud>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -187,7 +188,8 @@ Programmatically changing one of the attributes will result in the player being 
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ##### data-track
 

--- a/site/en/components/bento-stream-gallery.md
+++ b/site/en/components/bento-stream-gallery.md
@@ -89,7 +89,8 @@ defineBentoStreamGallery();
     </bento-stream-gallery>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Interactivity and API usage
 
@@ -223,7 +224,8 @@ This example demonstrates how to programmatically switch to the next/previous sl
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Attributes
 

--- a/site/en/components/bento-timeago.md
+++ b/site/en/components/bento-timeago.md
@@ -120,7 +120,8 @@ defineBentoTimeago();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -270,7 +271,8 @@ By programmatically changing attribute values, you can dynamically change the te
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ---
 

--- a/site/en/components/bento-twitter.md
+++ b/site/en/components/bento-twitter.md
@@ -85,7 +85,8 @@ defineBentoTwitters();
     <bento-twitter id="my-tweet" data-tweetid="885634330868850689"></bento-twitter>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -205,7 +206,8 @@ Programmatically changing any of the attribute values will automatically update 
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ---
 

--- a/site/en/components/bento-wordpress-embed.md
+++ b/site/en/components/bento-wordpress-embed.md
@@ -84,7 +84,8 @@ defineBentoWordpressEmbed();
     ></bento-wordpress-embed>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -180,7 +181,8 @@ The URL of the post to embed. Programmatically changing the attribute value will
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ---
 

--- a/site/en/components/bento-youtube.md
+++ b/site/en/components/bento-youtube.md
@@ -83,7 +83,8 @@ defineBentoYoutube();
     <bento-youtube data-videoid="dQw4w9WgXcQ"></bento-youtube>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 ### Layout and style
 
@@ -253,7 +254,8 @@ const api = await video.getApi();
     </script>
   </body>
 </html>
-```{% endexample %}
+```
+{% endexample %}
 
 #### Actions
 


### PR DESCRIPTION
The closing {% endexample %} tags are currently placed on the same line as closing fenced code block tags (```). While Eleventy seems to render pages correctly, this still results in incorrect parsing of the markdown files by translation platforms (and by GitHub - see screenshot). 
This PR adds extra line breaks to separate the {% endexample %} tags from code blocks so we can correctly parse the files for translation.

![Screenshot 2022-01-05 at 17 59 33](https://user-images.githubusercontent.com/8548803/148258579-0fa1139e-0393-4ef8-a9c7-6d6ebce5c29f.png)
