### PR TITLE
Add support for explicit id attributes of headings

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -47,6 +47,27 @@ module.exports = (eleventyConfig) => {
       breaks: true,
     })
       .use(markdownItAnchor)
+
+  
+      // Let folks customize markdown output with attributes (id, class, data-*)
+      .use(require('markdown-it-attrs'), {
+        leftDelimiter: '{:',
+        rightDelimiter: '}',
+        allowedAttributes: ['id', 'class', /^data-.*$/],
+      })
+
+      // Automatically add anchors to headings
+      /*
+      .use(require('markdown-it-anchor'), {
+        level: 2,
+        permalink: true,
+        permalinkClass: 'w-headline-link',
+        permalinkSymbol: '#',
+        // @ts-ignore
+        slugify: (s) => slugify(s, {lower: true}),
+      })
+      */
+
       .use(markdownItContainer, 'raw', {
         render: (tokens, idx) => {
           return '\n';

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "html-minifier": "4.0.0",
     "lodash.get": "4.4.2",
     "markdown-it-anchor": "8.4.1",
+    "markdown-it-attrs": "^3.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.4.1",
     "purgecss": "4.0.3",


### PR DESCRIPTION
Heading ids are currently generated based on the heading text. As a result, in translated documents headings are not cross-referenced correctly. In the below example the button will link to an incorrect anchor: [https://bentojs.dev/de/components/bento-accordion/#web-component](https://bentojs.dev/de/components/bento-accordion/#web-component)
 
<img width="1042" alt="Screenshot 2022-01-08 at 18 25 10" src="https://user-images.githubusercontent.com/8548803/148652598-e55eb930-c32c-43a1-beca-f2740a9e02f2.png">

This PR adds support for explicitly setting the id attribute of headings in the Markdown documents to keep them consistent across translations. 

This implementation is the same as the one used in the web.dev project: [https://github.com/GoogleChrome/web.dev/blob/main/src/site/_plugins/markdown.js](https://github.com/GoogleChrome/web.dev/blob/main/src/site/_plugins/markdown.js)


In future, English documentation would need to [include explicit IDs](https://github.com/ampproject/bentojs.dev/issues/163) for the headings that are cross-referenced in the doc.