### PR TITLE
Update build paths to include src/bento/components

### DIFF
--- a/gulpfile.js/importDocs.js
+++ b/gulpfile.js/importDocs.js
@@ -8,6 +8,7 @@ const markdownItAnchor = require('markdown-it-anchor');
 const {split} = require('sentence-splitter');
 
 const EXTENSIONS_SRC = path.resolve(__dirname, '..', 'amphtml/extensions');
+const COMPONENTS_SRC = path.resolve(__dirname, '..', 'amphtml/src/bento/components');
 const COMPONENTS_DEST = path.resolve(__dirname, '..', 'site/en/components');
 const IGNORED_COMPONENTS = new Set(['bento-iframe']);
 const md = markdownIt({
@@ -146,7 +147,10 @@ function _parseComponentName(content) {
 }
 
 async function importComponents() {
-  const filePaths = await fg(path.join(EXTENSIONS_SRC, '**/1.0/README.md'));
+  const filePaths = await fg([
+    path.join(EXTENSIONS_SRC, '**/1.0/README.md'),
+    path.join(COMPONENTS_SRC, '**/1.0/README.md'),
+  ]);
   if (!filePaths.length) {
     console.error(
       chalk.dim('[Import components]'),

--- a/gulpfile.js/importHeroExamples.js
+++ b/gulpfile.js/importHeroExamples.js
@@ -4,15 +4,19 @@ const fg = require('fast-glob');
 const chalk = require('chalk');
 
 const EXTENSIONS_SRC = path.resolve(__dirname, '..', 'amphtml/extensions');
+const COMPONENTS_SRC = path.resolve(__dirname, '..', 'amphtml/src/bento/components');
 const EXAMPLES_DEST = path.resolve(
   __dirname,
   '..',
   'assets/iframes/hero-examples'
 );
-const PATH_COMPONENT_NAME_PATTERN = /amphtml\/extensions\/(.*?)\//m;
+const PATH_COMPONENT_NAME_PATTERN = /amphtml\/(?:extensions)|(?:src\/bento\/components)\/(.*?)\//m;
 
 async function importHeroExamples() {
-  const filePaths = await fg(path.join(EXTENSIONS_SRC, '**/1.0/example/**/*'));
+  const filePaths = await fg([
+    path.join(EXTENSIONS_SRC, '**/1.0/example/**/*'),
+    path.join(COMPONENTS_SRC, '**/1.0/example/**/*'),
+  ]);
   if (!filePaths.length) {
     console.error(
       chalk.dim('[Import hero examples]'),


### PR DESCRIPTION
As we migrate components within [amphtml](https://github.com/ampproject/amphtml) the location of their documentation is changing. This PR should ensure the new doc locations are picked up as well.

https://github.com/ampproject/amphtml/issues/36461